### PR TITLE
Update GameDetect.cpp

### DIFF
--- a/OpenParrot/src/Utility/GameDetect.cpp
+++ b/OpenParrot/src/Utility/GameDetect.cpp
@@ -698,6 +698,8 @@ void GameDetect::DetectCurrentGame()
 		case 0x9c7bb2e1: // Ver 11 TEST
 			SetGameId(GameID::TappingSkillTest, "Tapping Skill Test Generic");
 			break;
+		case 0x24DCF694: // FM17
+		case 0x2FF02A2E: // FM16
 		case 0x0bad58c2: // FM14
 		case 0x65753fe4: // FM13
 		case 0xd7028acd: // FM12


### PR DESCRIPTION
have only added v16 & v17 of doa 6 game exe crc's this time as i don't understand why it failed before. newlines? << does it have to be new entries and not mixed in with what's already there ?